### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: bash
+services: docker
+
+matrix:
+  include:
+    - os: linux
+      env: PYTHON_VERSION=2.7
+    - os: linux
+      env: PYTHON_VERSION=3.6
+
+before_script:
+  - image="ansible-lint:py${PYTHON_VERSION}"
+
+script:
+  - docker build --build-arg python_version=${PYTHON_VERSION} -t "$image"  .
+after_script:
+  - docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:2.7-alpine
+ARG python_version
+FROM python:${python_version}-alpine
 # ansible-lint use `except foo, e` syntax...
 
 COPY requirements.txt /


### PR DESCRIPTION
Hi!

Newer ansible versions tend to use python3 as default and "py2-compat".

Thus it would be nice to have ansible-lint running in a py3 environment.

Sorry,  i do not know circle-ci, thus i used a `.travis.yml` for showing the intent of the setup:
Create two docker images automatically, tagged by underlying python version.

Thanks a lot