### PR TITLE
Fix python-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache git \
     gcc \
     libc-dev \
     openssl-dev \
-    python-dev \
+    python3-dev \
     libffi-dev \
  && pip install -r requirements.txt \
  && runDeps="$( \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apk add --no-cache git \
     gcc \
     libc-dev \
     openssl-dev \
-    python3-dev \
     libffi-dev \
  && pip install -r requirements.txt \
  && runDeps="$( \


### PR DESCRIPTION
When building the image, I get this error:

```
ERROR: unsatisfiable constraints:
  python-dev (missing):
    required by: world[python-dev]
```

To fix, I updated the package from `python-dev` to `python3-dev`.